### PR TITLE
net: phytium: convert and remove validate() references

### DIFF
--- a/drivers/net/ethernet/phytium/phytmac_main.c
+++ b/drivers/net/ethernet/phytium/phytmac_main.c
@@ -1551,71 +1551,8 @@ static void phytmac_pcs_get_state(struct phylink_config *config,
 	state->link = hw_if->get_link(pdata, state->interface);
 }
 
-static void phytmac_validate(struct phylink_config *config,
-			     unsigned long *supported,
-			     struct phylink_link_state *state)
-{
-	struct net_device *ndev = to_net_dev(config->dev);
-	__ETHTOOL_DECLARE_LINK_MODE_MASK(mask) = { 0, };
-	struct phytmac *pdata = netdev_priv(ndev);
-
-	if (state->interface != PHY_INTERFACE_MODE_SGMII &&
-	    state->interface != PHY_INTERFACE_MODE_1000BASEX &&
-	    state->interface != PHY_INTERFACE_MODE_2500BASEX &&
-	    state->interface != PHY_INTERFACE_MODE_5GBASER &&
-	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
-	    state->interface != PHY_INTERFACE_MODE_USXGMII &&
-	    !phy_interface_mode_is_rgmii(state->interface)) {
-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
-		return;
-	}
-
-	phylink_set_port_modes(mask);
-	phylink_set(mask, Autoneg);
-	phylink_set(mask, Asym_Pause);
-
-	if (state->interface == PHY_INTERFACE_MODE_10GBASER ||
-	    state->interface == PHY_INTERFACE_MODE_USXGMII) {
-		pdata->speed = state->speed;
-		pdata->duplex = state->duplex;
-		if (pdata->speed == SPEED_5000) {
-			phylink_set(mask, 5000baseT_Full);
-		} else {
-			phylink_set(mask, 10000baseCR_Full);
-			phylink_set(mask, 10000baseER_Full);
-			phylink_set(mask, 10000baseKR_Full);
-			phylink_set(mask, 10000baseLR_Full);
-			phylink_set(mask, 10000baseLRM_Full);
-			phylink_set(mask, 10000baseSR_Full);
-			phylink_set(mask, 10000baseT_Full);
-		}
-	}
-
-	if (state->interface == PHY_INTERFACE_MODE_2500BASEX)
-		phylink_set(mask, 2500baseX_Full);
-
-	if (state->interface == PHY_INTERFACE_MODE_5GBASER)
-		phylink_set(mask, 5000baseT_Full);
-
-	if (state->interface == PHY_INTERFACE_MODE_1000BASEX ||
-	    state->interface == PHY_INTERFACE_MODE_SGMII ||
-	    phy_interface_mode_is_rgmii(state->interface)) {
-		phylink_set(mask, 1000baseT_Full);
-		phylink_set(mask, 1000baseX_Full);
-		phylink_set(mask, 1000baseT_Half);
-		phylink_set(mask, 10baseT_Half);
-		phylink_set(mask, 10baseT_Full);
-		phylink_set(mask, 100baseT_Half);
-		phylink_set(mask, 100baseT_Full);
-	}
-
-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
-	bitmap_and(state->advertising, state->advertising, mask,
-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
-}
-
 static const struct phylink_mac_ops phytmac_phylink_ops = {
-	.validate = phytmac_validate,
+	// .validate = phytmac_validate,
 	.mac_select_pcs = phytmac_mac_select_pcs,
 	.mac_config = phytmac_mac_config,
 	.mac_link_down = phytmac_mac_link_down,
@@ -1628,7 +1565,9 @@ static inline void set_phy_interface(unsigned long *intf)
 	__set_bit(PHY_INTERFACE_MODE_1000BASEX, intf);
 	__set_bit(PHY_INTERFACE_MODE_2500BASEX, intf);
 	__set_bit(PHY_INTERFACE_MODE_USXGMII, intf);
+	__set_bit(PHY_INTERFACE_MODE_5GBASER, intf);
 	__set_bit(PHY_INTERFACE_MODE_10GBASER, intf);
+	phy_interface_set_rgmii(intf);
 }
 
 static int phytmac_phylink_create(struct phytmac *pdata)
@@ -1648,6 +1587,10 @@ static int phytmac_phylink_create(struct phytmac *pdata)
 	}
 
 	set_phy_interface(pdata->phylink_config.supported_interfaces);
+	pdata->phylink_config.mac_capabilities = MAC_ASYM_PAUSE |
+		MAC_10 | MAC_100 | MAC_1000 | MAC_2500FD |
+		MAC_5000FD | MAC_10000FD;
+
 	pdata->phylink = phylink_create(&pdata->phylink_config, fw_node,
 					pdata->phy_interface, &phytmac_phylink_ops);
 	if (IS_ERR(pdata->phylink)) {


### PR DESCRIPTION
Populate the supported interfaces bitmap and MAC capabilities mask for
    the phytium driver and remove the old validate implementation.
Link:https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=cc0a75eb037539f68f7117a632673a75e39d8d6b