### PR TITLE
char: phytnet_led: Convert to platform remove callback returning void

### DIFF
--- a/drivers/char/phytnetled/phytnet_led.c
+++ b/drivers/char/phytnetled/phytnet_led.c
@@ -277,7 +277,7 @@ net_led_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int
+static void
 net_led_remove(struct platform_device *pdev)
 {
 	struct led_data *phytnet_led = platform_get_drvdata(pdev);
@@ -299,8 +299,6 @@ net_led_remove(struct platform_device *pdev)
 	}
 
 	devm_kfree(&pdev->dev, phytnet_led);
-
-	return 0;
 }
 
 static struct platform_driver net_led_driver = {


### PR DESCRIPTION
0edb555a6: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/char/phytnetled/phytnet_led.c:314:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  314 |         .remove = net_led_remove,
      |                   ^~~~~~~~~~~~~~
drivers/char/phytnetled/phytnet_led.c:314:19: note: (near initialization for ‘net_led_driver.<anonymous>.remove’)
cc1: all warnings being treated as errors