### PR TITLE
dma: phytium-ddmac: Convert to platform remove callback returning void

### DIFF
--- a/drivers/dma/phytium/phytium-ddmac.c
+++ b/drivers/dma/phytium/phytium-ddmac.c
@@ -843,7 +843,7 @@ static void phytium_ddma_chan_remove(struct phytium_ddma_chan *chan)
 	list_del(&chan->vchan.chan.device_node);
 }
 
-static int phytium_ddma_remove(struct platform_device *pdev)
+static void phytium_ddma_remove(struct platform_device *pdev)
 {
 	struct phytium_ddma_device *ddma = platform_get_drvdata(pdev);
 	struct phytium_ddma_chan *chan = NULL;
@@ -859,8 +859,6 @@ static int phytium_ddma_remove(struct platform_device *pdev)
 
 	phytium_ddma_irq_disable(ddma);
 	phytium_ddma_disable(ddma);
-
-	return 0;
 }
 
 #ifdef CONFIG_PM_SLEEP


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/pci/controller/pcie-phytium-ep.c:462:19: note: (near initialization for ‘phytium_pcie_ep_driver.<anonymous>.remove’) drivers/dma/phytium/phytium-ddmac.c:948:27: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  948 |         .remove         = phytium_ddma_remove,
      |                           ^~~~~~~~~~~~~~~~~~~