### PR TITLE
sound: hda_phytium: Convert to platform remove callback returning void

### DIFF
--- a/sound/pci/hda/hda_phytium.c
+++ b/sound/pci/hda/hda_phytium.c
@@ -1021,7 +1021,7 @@ out_free:
 	return err;
 }
 
-static int hda_ft_remove(struct platform_device *pdev)
+static void hda_ft_remove(struct platform_device *pdev)
 {
 	struct snd_card *card = dev_get_drvdata(&pdev->dev);
 	struct azx *chip;
@@ -1035,9 +1035,7 @@ static int hda_ft_remove(struct platform_device *pdev)
 		clear_bit(chip->dev_index, probed_devs);
 
 		snd_card_free(card);
-		return 0;
 	}
-	return 0;
 }
 
 static void hda_ft_shutdown(struct platform_device *pdev)


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
sound/pci/hda/hda_phytium.c:1079:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
 1079 |         .remove = hda_ft_remove,
      |                   ^~~~~~~~~~~~~
sound/pci/hda/hda_phytium.c:1079:19: note: (near initialization for ‘ft_platform_hda.<anonymous>.remove’)