### PR TITLE
pci: pcie-phytium-ep: Convert to platform remove callback returning void

### DIFF
--- a/drivers/pci/controller/pcie-phytium-ep.c
+++ b/drivers/pci/controller/pcie-phytium-ep.c
@@ -437,15 +437,13 @@ err_alloc_irq_mem:
 	return ret;
 }
 
-static int phytium_pcie_ep_remove(struct platform_device *pdev)
+static void phytium_pcie_ep_remove(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct phytium_pcie_ep *priv = dev_get_drvdata(dev);
 	struct pci_epc *epc = priv->epc;
 
 	pci_epc_mem_exit(epc);
-
-	return 0;
 }
 
 static const struct of_device_id phytium_pcie_ep_of_match[] = {


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/pci/controller/pcie-phytium-ep.c:462:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  462 |         .remove = phytium_pcie_ep_remove,
      |                   ^~~~~~~~~~~~~~~~~~~~~~
drivers/pci/controller/pcie-phytium-ep.c:462:19: note: (near initialization for ‘phytium_pcie_ep_driver.<anonymous>.remove’)