### PR TITLE
sound: soc: phytium_i2s: Convert to platform remove callback returnin…

### DIFF
--- a/sound/soc/phytium/phytium_i2s.c
+++ b/sound/soc/phytium/phytium_i2s.c
@@ -1395,10 +1395,9 @@ failed_get_dai_name:
 	return ret;
 }
 
-static int phytium_i2s_remove(struct platform_device *pdev)
+static void phytium_i2s_remove(struct platform_device *pdev)
 {
 	pm_runtime_disable(&pdev->dev);
-	return 0;
 }
 
 static const struct of_device_id phytium_i2s_of_match[] = {


### PR DESCRIPTION
…g void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
sound/soc/phytium/phytium_i2s.c:1421:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
 1421 |         .remove = phytium_i2s_remove,
      |                   ^~~~~~~~~~~~~~~~~~
sound/soc/phytium/phytium_i2s.c:1421:19: note: (near initialization for ‘phytium_i2s_driver.<anonymous>.remove’)