### PR TITLE
lpc: phytium-lpc-snoop: Convert to platform remove callback returning…

### DIFF
--- a/drivers/misc/phytium-lpc-snoop.c
+++ b/drivers/misc/phytium-lpc-snoop.c
@@ -291,15 +291,13 @@ static int phytium_lpc_snoop_probe(struct platform_device *pdev)
 	return rc;
 }
 
-static int phytium_lpc_snoop_remove(struct platform_device *pdev)
+static void phytium_lpc_snoop_remove(struct platform_device *pdev)
 {
 	struct phytium_lpc_snoop *lpc_snoop = dev_get_drvdata(&pdev->dev);
 
 	/* Disable both snoop channels */
 	phytium_lpc_disable_snoop(lpc_snoop, 0);
 	phytium_lpc_disable_snoop(lpc_snoop, 1);
-
-	return 0;
 }
 
 


### PR DESCRIPTION
… void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/misc/phytium-lpc-snoop.c:317:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  317 |         .remove = phytium_lpc_snoop_remove,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
drivers/misc/phytium-lpc-snoop.c:317:19: note: (near initialization for ‘phytium_lpc_snoop_driver.<anonymous>.remove’)