### PR TITLE
usb: phytium: platform: Convert to platform remove callback returning…

### DIFF
--- a/drivers/usb/phytium/platform.c
+++ b/drivers/usb/phytium/platform.c
@@ -128,12 +128,12 @@ static int phytium_driver_probe(struct platform_device *pdev)
 	return retval;
 }
 
-static int phytium_driver_remove(struct platform_device *dev)
+static void phytium_driver_remove(struct platform_device *dev)
 {
 	struct phytium_cusb *config = platform_get_drvdata(dev);
 
 	if (!config)
-		return 0;
+		return;
 
 	phytium_get_dr_mode(config);
 
@@ -146,7 +146,6 @@ static int phytium_driver_remove(struct platform_device *dev)
 		phytium_gadget_uninit(config);
 
 	dev_set_drvdata(&dev->dev, NULL);
-	return 0;
 }
 
 static void phytium_driver_shutdown(struct platform_device *dev)


### PR DESCRIPTION
… void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/usb/phytium/platform.c:208:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  208 |         .remove = phytium_driver_remove,
      |                   ^~~~~~~~~~~~~~~~~~~~~
drivers/usb/phytium/platform.c:208:19: note: (near initialization for ‘phytium_otg_driver.<anonymous>.remove’)