### PR TITLE
Input: phytium-keypad: Convert to platform remove callback returning …

### DIFF
--- a/drivers/input/keyboard/phytium-keypad.c
+++ b/drivers/input/keyboard/phytium-keypad.c
@@ -498,14 +498,12 @@ static int phytium_keypad_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int phytium_keypad_remove(struct platform_device *pdev)
+static void phytium_keypad_remove(struct platform_device *pdev)
 {
 	struct phytium_keypad *keypad = platform_get_drvdata(pdev);
 
 	input_unregister_device(keypad->input_dev);
 	devm_kfree(&pdev->dev, keypad);
-
-	return 0;
 }
 
 #ifdef CONFIG_PM_SLEEP


### PR DESCRIPTION
…void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/input/keyboard/phytium-keypad.c:562:23: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  562 |         .remove     = phytium_keypad_remove,
      |                       ^~~~~~~~~~~~~~~~~~~~~
drivers/input/keyboard/phytium-keypad.c:562:23: note: (near initialization for ‘phytium_keypad_driver.<anonymous>.remove’)