### PR TITLE
i2c: phytium: Convert to platform remove callback returning void

### DIFF
--- a/drivers/i2c/busses/i2c-phytium-platform.c
+++ b/drivers/i2c/busses/i2c-phytium-platform.c
@@ -290,7 +290,7 @@ exit_reset:
 	return ret;
 }
 
-static int phytium_i2c_plat_remove(struct platform_device *pdev)
+static void phytium_i2c_plat_remove(struct platform_device *pdev)
 {
 	struct phytium_i2c_dev *dev = platform_get_drvdata(pdev);
 
@@ -306,8 +306,6 @@ static int phytium_i2c_plat_remove(struct platform_device *pdev)
 
 	if (!IS_ERR_OR_NULL(dev->rst))
 		reset_control_assert(dev->rst);
-
-	return 0;
 }
 
 #ifdef CONFIG_OF


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/i2c/busses/i2c-phytium-platform.c:351:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  351 |         .remove = phytium_i2c_plat_remove,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~
drivers/i2c/busses/i2c-phytium-platform.c:351:19: note: (near initialization for ‘phytium_i2c_driver.<anonymous>.remove’)