### PR TITLE
net: ethernet: phytmac: Convert to platform remove callback returning…

### DIFF
--- a/drivers/net/ethernet/phytium/phytmac_platform.c
+++ b/drivers/net/ethernet/phytium/phytmac_platform.c
@@ -204,14 +204,12 @@ err_alloc:
 	return ret;
 }
 
-static int phytmac_plat_remove(struct platform_device *pdev)
+static void phytmac_plat_remove(struct platform_device *pdev)
 {
 	struct phytmac *pdata = platform_get_drvdata(pdev);
 
 	phytmac_drv_remove(pdata);
 	phytmac_free_pdata(pdata);
-
-	return 0;
 }
 
 static int __maybe_unused phytmac_plat_suspend(struct device *dev)


### PR DESCRIPTION
… void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

drivers/net/ethernet/phytium/phytmac_platform.c:243:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  243 |         .remove = phytmac_plat_remove,
      |                   ^~~~~~~~~~~~~~~~~~~
drivers/net/ethernet/phytium/phytmac_platform.c:243:19: note: (near initialization for ‘phytmac_driver.<anonymous>.remove’)