### PR TITLE
net: phytmac_ethtool: Add struct kernel_ethtool_ts_info

### DIFF
--- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
+++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
@@ -176,7 +176,7 @@ static int phytmac_set_ringparam(struct net_device *ndev,
 }
 
 static int phytmac_get_ts_info(struct net_device *ndev,
-			       struct ethtool_ts_info *info)
+			       struct kernel_ethtool_ts_info *info)
 {
 	struct phytmac *pdata = netdev_priv(ndev);
 


### PR DESCRIPTION
2111375b85a: net: Add struct kernel_ethtool_ts_info cause build error, so convert ethtool_ts_info to kernel_ethtool_ts_info

Log:
drivers/net/ethernet/phytium/phytmac_ethtool.c: In function ‘phytmac_get_ts_info’: drivers/net/ethernet/phytium/phytmac_ethtool.c:204:45: error: passing argument 2 of ‘ethtool_op_get_ts_info’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  204 |         return ethtool_op_get_ts_info(ndev, info);
      |                                             ^~~~
      |                                             |
      |                                             struct ethtool_ts_info *
In file included from drivers/net/ethernet/phytium/phytmac_ethtool.c:3:
./include/linux/ethtool.h:1205:59: note: expected ‘struct kernel_ethtool_ts_info *’ but argument is of type ‘struct ethtool_ts_info *’
 1205 |                            struct kernel_ethtool_ts_info *eti);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
drivers/net/ethernet/phytium/phytmac_ethtool.c: At top level:
drivers/net/ethernet/phytium/phytmac_ethtool.c:522:43: error: initialization of ‘int (*)(struct net_device *, struct kernel_ethtool_ts_info *)’ from incompatible pointer type ‘int (*)(struct net_device *, struct ethtool_ts_info *)’ [-Werror=incompatible-pointer-types]
  522 |         .get_ts_info                    = phytmac_get_ts_info,
      |                                           ^~~~~~~~~~~~~~~~~~~
drivers/net/ethernet/phytium/phytmac_ethtool.c:522:43: note: (near initialization for ‘phytmac_ethtool_ops.get_ts_info’)
cc1: all warnings being treated as errors