### PR TITLE
edac: phytium_edac: Convert to platform remove callback returning void

### DIFF
--- a/drivers/edac/phytium_edac.c
+++ b/drivers/edac/phytium_edac.c
@@ -450,13 +450,11 @@ out:
 	return ret;
 }
 
-static int phytium_edac_remove(struct platform_device *pdev)
+static void phytium_edac_remove(struct platform_device *pdev)
 {
 	struct phytium_edac *edac = dev_get_drvdata(&pdev->dev);
 
 	phytium_edac_device_remove(edac);
-
-	return 0;
 }
 
 static const struct of_device_id phytium_edac_of_match[] = {


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/edac/phytium_edac.c:470:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  470 |         .remove = phytium_edac_remove,
      |                   ^~~~~~~~~~~~~~~~~~~
drivers/edac/phytium_edac.c:470:19: note: (near initialization for ‘phytium_edac_driver.<anonymous>.remove’)