### PR TITLE
mmc: phytium-sdci: Convert to platform remove callback returning void

### DIFF
--- a/drivers/mmc/host/phytium-sdci.c
+++ b/drivers/mmc/host/phytium-sdci.c
@@ -1329,7 +1329,7 @@ host_free:
 	return ret;
 }
 
-static int phytium_sdci_remove(struct platform_device *pdev)
+static void phytium_sdci_remove(struct platform_device *pdev)
 {
 	struct mmc_host *mmc;
 	struct phytium_sdci_host *host;
@@ -1347,8 +1347,6 @@ static int phytium_sdci_remove(struct platform_device *pdev)
 				  host->dma_rx.buf, host->dma_rx.bd_addr);
 
 	mmc_free_host(host->mmc);
-
-	return 0;
 }
 
 #ifdef CONFIG_PM_SLEEP


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/mmc/host/phytium-sdci.c:1426:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
 1426 |         .remove = phytium_sdci_remove,
      |                   ^~~~~~~~~~~~~~~~~~~
drivers/mmc/host/phytium-sdci.c:1426:19: note: (near initialization for ‘phytium_sdci_driver.<anonymous>.remove’)