### PR TITLE
firmware: arm_scmi: mailbox: fix unused var error

### DIFF
--- a/drivers/firmware/arm_scmi/transports/mailbox.c
+++ b/drivers/firmware/arm_scmi/transports/mailbox.c
@@ -185,8 +185,6 @@ static int mailbox_chan_setup(struct scmi_chan_info *cinfo, struct device *dev,
 	struct scmi_mailbox *smbox;
 	int ret, a2p_rx_chan, p2a_chan, p2a_rx_chan;
 	struct mbox_client *cl;
-	resource_size_t size;
-	struct resource res;
 	struct of_phandle_args args;
 
 	ret = mailbox_chan_validate(cdev, &a2p_rx_chan, &p2a_chan, &p2a_rx_chan);


### PR DESCRIPTION
Log:
drivers/firmware/arm_scmi/transports/mailbox.c: In function ‘mailbox_chan_setup’: drivers/firmware/arm_scmi/transports/mailbox.c:189:25: error: unused variable ‘res’ [-Werror=unused-variable]
  189 |         struct resource res;
      |                         ^~~
drivers/firmware/arm_scmi/transports/mailbox.c:188:25: error: unused variable ‘size’ [-Werror=unused-variable]
  188 |         resource_size_t size;
      |                         ^~~~