### PR TITLE
mailbox: phytium_mailbox: Convert to platform remove callback returni…

### DIFF
--- a/drivers/mailbox/phytium_mailbox.c
+++ b/drivers/mailbox/phytium_mailbox.c
@@ -170,13 +170,11 @@ fail:
 	return err;
 }
 
-static int phytium_mbox_remove(struct platform_device *pdev)
+static void phytium_mbox_remove(struct platform_device *pdev)
 {
 	struct phytium_mbox *mbox = platform_get_drvdata(pdev);
 
 	mbox_controller_unregister(&mbox->mbox);
-
-	return 0;
 }
 
 static struct platform_driver phytium_mbox_driver = {


### PR DESCRIPTION
…ng void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void


Log:
drivers/mailbox/phytium_mailbox.c:184:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  184 |         .remove = phytium_mbox_remove,
      |                   ^~~~~~~~~~~~~~~~~~~
drivers/mailbox/phytium_mailbox.c:184:19: note: (near initialization for ‘phytium_mbox_driver.<anonymous>.remove’)