### PR TITLE
perf: phytium_pcie_pmu: Convert to platform remove callback returning…

### DIFF
--- a/drivers/perf/phytium/phytium_pcie_pmu.c
+++ b/drivers/perf/phytium/phytium_pcie_pmu.c
@@ -788,7 +788,7 @@ static int phytium_pcie_pmu_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int phytium_pcie_pmu_remove(struct platform_device *pdev)
+static void phytium_pcie_pmu_remove(struct platform_device *pdev)
 {
 	struct phytium_pcie_pmu *pcie_pmu = platform_get_drvdata(pdev);
 
@@ -797,8 +797,6 @@ static int phytium_pcie_pmu_remove(struct platform_device *pdev)
 	perf_pmu_unregister(&pcie_pmu->pmu);
 	cpuhp_state_remove_instance_nocalls(
 		phytium_pcie_pmu_hp_state, &pcie_pmu->node);
-
-	return 0;
 }
 
 static struct platform_driver phytium_pcie_pmu_driver = {


### PR DESCRIPTION
… void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/perf/phytium/phytium_pcie_pmu.c:811:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  811 |         .remove = phytium_pcie_pmu_remove,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~
drivers/perf/phytium/phytium_pcie_pmu.c:811:19: note: (near initialization for ‘phytium_pcie_pmu_driver.<anonymous>.remove’)