### PR TITLE
char: ipmi: bt_bmc_phytium: Convert to platform remove callback retur…

### DIFF
--- a/drivers/char/ipmi/bt_bmc_phytium.c
+++ b/drivers/char/ipmi/bt_bmc_phytium.c
@@ -500,15 +500,13 @@ static int bt_bmc_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int bt_bmc_remove(struct platform_device *pdev)
+static void bt_bmc_remove(struct platform_device *pdev)
 {
 	struct bt_bmc *bt_bmc = dev_get_drvdata(&pdev->dev);
 
 	misc_deregister(&bt_bmc->miscdev);
 	if (!bt_bmc->irq)
 		del_timer_sync(&bt_bmc->poll_timer);
-
-	return 0;
 }
 
 static const struct of_device_id bt_bmc_match[] = {


### PR DESCRIPTION
…ning void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/char/ipmi/bt_bmc_phytium.c:526:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  526 |         .remove = bt_bmc_remove,
      |                   ^~~~~~~~~~~~~
drivers/char/ipmi/bt_bmc_phytium.c:526:19: note: (near initialization for ‘bt_bmc_driver.<anonymous>.remove’)