### PR TITLE
char: ipmi: kcs_bmc_phytium: Convert to platform remove callback retu…

### DIFF
--- a/drivers/char/ipmi/kcs_bmc_phytium.c
+++ b/drivers/char/ipmi/kcs_bmc_phytium.c
@@ -400,7 +400,7 @@ static int phytium_kcs_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int phytium_kcs_remove(struct platform_device *pdev)
+static void phytium_kcs_remove(struct platform_device *pdev)
 {
 	struct phytium_kcs_bmc *priv = platform_get_drvdata(pdev);
 	struct kcs_bmc_device *kcs_bmc = &priv->kcs_bmc;
@@ -413,7 +413,6 @@ static int phytium_kcs_remove(struct platform_device *pdev)
 	priv->obe.remove = true;
 	spin_unlock_irq(&priv->obe.lock);
 	del_timer_sync(&priv->obe.timer);
-	return 0;
 }
 
 static const struct of_device_id phytium_kcs_bmc_match[] = {


### PR DESCRIPTION
…rning void

0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/char/ipmi/kcs_bmc_phytium.c:431:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  431 |         .remove = phytium_kcs_remove,
      |                   ^~~~~~~~~~~~~~~~~~
drivers/char/ipmi/kcs_bmc_phytium.c:431:19: note: (near initialization for ‘phytium_kcs_bmc_driver.<anonymous>.remove’)