### PR TITLE
mtd: nand: phytium: Convert to platform remove callback returning void

### DIFF
--- a/drivers/mtd/nand/raw/phytium_nand_plat.c
+++ b/drivers/mtd/nand/raw/phytium_nand_plat.c
@@ -85,11 +85,10 @@ static int phytium_nfc_plat_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int phytium_nfc_plat_remove(struct platform_device *pdev)
+static void phytium_nfc_plat_remove(struct platform_device *pdev)
 {
 	struct phytium_nfc *nfc = platform_get_drvdata(pdev);
-
-	return phytium_nand_remove(nfc);
+	phytium_nand_remove(nfc);
 }
 
 static int __maybe_unused phytium_nfc_plat_prepare(struct device *dev)


### PR DESCRIPTION
0edb555: platform: Make platform_driver::remove() return void cause build error, so convert .remove from int to void

Log:
drivers/mtd/nand/raw/phytium_nand_plat.c:132:19: error: initialization of ‘void (*)(struct platform_device *)’ from incompatible pointer type ‘int (*)(struct platform_device *)’ [-Werror=incompatible-pointer-types]
  132 |         .remove = phytium_nfc_plat_remove,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~
drivers/mtd/nand/raw/phytium_nand_plat.c:132:19: note: (near initialization for ‘phytium_nfc_plat_driver.<anonymous>.remove’)